### PR TITLE
Add support for tomcat factory attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>>scm:git:git//github.com/h-thurow/Simple-JNDI.git</connection>
+		<connection>scm:git:git//github.com/h-thurow/Simple-JNDI.git</connection>
 		<developerConnection>scm:git:ssh//github.com/h-thurow/Simple-JNDI.git
         </developerConnection>
 		<url>https://github.com/h-thurow/Simple-JNDI</url>

--- a/src/main/java/org/osjava/sj/jndi/JndiUtils.java
+++ b/src/main/java/org/osjava/sj/jndi/JndiUtils.java
@@ -23,7 +23,8 @@ public class JndiUtils {
     }
 
     public static Reference toReference(Properties props, String className) {
-        Reference ref = new Reference(className);
+        final String factory = props.getProperty("factory", null);
+        Reference ref = new Reference(className, factory, null);
         for (Object key : props.keySet()) {
             ref.add(new StringRefAddr((String) key, props.getProperty((String) key)));
         }

--- a/src/main/java/org/osjava/sj/jndi/JndiUtils.java
+++ b/src/main/java/org/osjava/sj/jndi/JndiUtils.java
@@ -23,7 +23,7 @@ public class JndiUtils {
     }
 
     public static Reference toReference(Properties props, String className) {
-        final String factory = props.getProperty("factory", null);
+        final String factory = props.getProperty("javaxNamingSpiObjectFactory", null);
         Reference ref = new Reference(className, factory, null);
         for (Object key : props.keySet()) {
             ref.add(new StringRefAddr((String) key, props.getProperty((String) key)));

--- a/src/main/java/org/osjava/sj/loader/JndiLoader.java
+++ b/src/main/java/org/osjava/sj/loader/JndiLoader.java
@@ -404,7 +404,7 @@ public class JndiLoader {
     @Nullable
     Object processType(Properties properties, String type, Object obj) {
         Object o = null;
-        if (environment.containsKey(Context.OBJECT_FACTORIES) || properties.containsKey("factory")) {
+        if (environment.containsKey(Context.OBJECT_FACTORIES) || properties.containsKey("javaxNamingSpiObjectFactory")) {
             try {
                 Reference reference = JndiUtils.toReference(properties, type);
                 o = NamingManager.getObjectInstance(reference, null, null, environment);

--- a/src/main/java/org/osjava/sj/loader/JndiLoader.java
+++ b/src/main/java/org/osjava/sj/loader/JndiLoader.java
@@ -404,7 +404,7 @@ public class JndiLoader {
     @Nullable
     Object processType(Properties properties, String type, Object obj) {
         Object o = null;
-        if (environment.containsKey(Context.OBJECT_FACTORIES)) {
+        if (environment.containsKey(Context.OBJECT_FACTORIES) || properties.containsKey("factory")) {
             try {
                 Reference reference = JndiUtils.toReference(properties, type);
                 o = NamingManager.getObjectInstance(reference, null, null, environment);

--- a/src/test/java/spi/objectfactories/SpiObjectFactoryTest.java
+++ b/src/test/java/spi/objectfactories/SpiObjectFactoryTest.java
@@ -8,6 +8,7 @@ import org.osjava.sj.loader.JndiLoader;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import java.util.Hashtable;
 import java.util.Properties;
 
@@ -105,5 +106,39 @@ public class SpiObjectFactoryTest {
         assertEquals(DemoBean2.class.getName(), demoBean2.getClass().getName());
     }
 
+    @Test
+    public void demoJavaxNamingSpiObjectFactory() throws NamingException {
+        Hashtable env = new Hashtable();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, MemoryContextFactory.class.getName());
+        env.put("org.osjava.sj.jndi.shared", "true");
+        env.put("org.osjava.sj.delimiter", ".");
+        env.put("jndi.syntax.separator", "/");
+        env.put("jndi.syntax.direction", "left_to_right");
 
+        Properties properties = new Properties();
+
+        // DemoBean1 configuration
+        properties.setProperty("org.osjava.sj.myBean.type", DemoBean.class.getName());
+        properties.setProperty("org.osjava.sj.myBean.javaxNamingSpiObjectFactory", DemoBeanFactory.class.getName());
+        properties.setProperty("org.osjava.sj.myBean.size", "186");
+        properties.setProperty("org.osjava.sj.myBean.fullName", "Holger Thurow");
+
+        // DemoBean2 configuration
+        properties.setProperty("org.osjava.sj.myBean2.type", DemoBean2.class.getName());
+        properties.setProperty("org.osjava.sj.myBean2.javaxNamingSpiObjectFactory", DemoBeanFactory2.class.getName());
+        properties.setProperty("org.osjava.sj.myBean2.inhabitants", "3754418");
+        properties.setProperty("org.osjava.sj.myBean2.city", "Berlin");
+
+        ctx = new InitialContext(env);
+        JndiLoader loader = new JndiLoader(env);
+        loader.load(properties, ctx);
+
+        Object demoBean1 = ctx.lookup("org/osjava/sj/myBean");
+        assertNotNull(demoBean1);
+        assertEquals(DemoBean.class.getName(), demoBean1.getClass().getName());
+
+        Object demoBean2 = ctx.lookup("org/osjava/sj/myBean2");
+        assertNotNull(demoBean2);
+        assertEquals(DemoBean2.class.getName(), demoBean2.getClass().getName());
+    }
 }


### PR DESCRIPTION
If you're trying to migrate Resources from Tomcat context you might come across "**factory**" attribute which specifies object factory. When you have multiple resources with different **type**s you can't use `java.naming.factory.object` as often wrong factory object is used. This change allows you to specify correct factory and create these objects.

Example:
```
amqp/connection/type=a.b.c.ConnectionWrapper
amqp/connection/factory=a.b.c.ConnectionFactory
amqp/connection/host=localhost
amqp/connection/port=5672
```