### PR TITLE
Update from commons-lang2 to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>

--- a/src/main/java/org/osjava/StringsToTypes.java
+++ b/src/main/java/org/osjava/StringsToTypes.java
@@ -1,6 +1,6 @@
 package org.osjava;
 
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/org/osjava/datasource/PoolSetup.java
+++ b/src/main/java/org/osjava/datasource/PoolSetup.java
@@ -1,32 +1,32 @@
 /*
  * Copyright (c) 2003, Henri Yandell
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or 
- * without modification, are permitted provided that the 
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the
  * following conditions are met:
- * 
- * + Redistributions of source code must retain the above copyright notice, 
+ *
+ * + Redistributions of source code must retain the above copyright notice,
  *   this list of conditions and the following disclaimer.
- * 
- * + Redistributions in binary form must reproduce the above copyright notice, 
- *   this list of conditions and the following disclaimer in the documentation 
+ *
+ * + Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
- * + Neither the name of Simple-JNDI nor the names of its contributors 
- *   may be used to endorse or promote products derived from this software 
+ *
+ * + Neither the name of Simple-JNDI nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
  *   without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -36,8 +36,8 @@ import org.apache.commons.dbcp.ConnectionFactory;
 import org.apache.commons.dbcp.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp.PoolableConnectionFactory;
 import org.apache.commons.dbcp.PoolingDriver;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.pool.impl.GenericObjectPool;
 
 import java.sql.DriverManager;

--- a/src/main/java/org/osjava/sj/MemoryContextFactory.java
+++ b/src/main/java/org/osjava/sj/MemoryContextFactory.java
@@ -40,7 +40,7 @@
 
 package org.osjava.sj;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.osjava.sj.jndi.MemoryContext;
 
 import javax.naming.Context;

--- a/src/main/java/org/osjava/sj/SimpleJndi.java
+++ b/src/main/java/org/osjava/sj/SimpleJndi.java
@@ -31,8 +31,8 @@
  */
 package org.osjava.sj;
 
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osjava.sj.loader.JndiLoader;

--- a/src/main/java/org/osjava/sj/SimpleJndiContextFactory.java
+++ b/src/main/java/org/osjava/sj/SimpleJndiContextFactory.java
@@ -30,7 +30,7 @@
 
 package org.osjava.sj;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.osjava.sj.jndi.DelimiterConvertingContext;
 
 import javax.naming.Context;

--- a/src/main/java/org/osjava/sj/jndi/MemoryContext.java
+++ b/src/main/java/org/osjava/sj/jndi/MemoryContext.java
@@ -32,7 +32,7 @@
 
 package org.osjava.sj.jndi;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;

--- a/src/main/java/org/osjava/sj/loader/FileBasedJndiLoader.java
+++ b/src/main/java/org/osjava/sj/loader/FileBasedJndiLoader.java
@@ -1,7 +1,7 @@
 package org.osjava.sj.loader;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/osjava/sj/loader/NioBasedJndiLoader.java
+++ b/src/main/java/org/osjava/sj/loader/NioBasedJndiLoader.java
@@ -1,7 +1,7 @@
 package org.osjava.sj.loader;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/osjava/sj/loader/SJProperties.java
+++ b/src/main/java/org/osjava/sj/loader/SJProperties.java
@@ -32,8 +32,8 @@
 
 package org.osjava.sj.loader;
 
-import org.apache.commons.lang.text.StrLookup;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrLookup;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;

--- a/src/main/java/org/osjava/sj/loader/convert/BeanConverter.java
+++ b/src/main/java/org/osjava/sj/loader/convert/BeanConverter.java
@@ -32,8 +32,8 @@
 
 package org.osjava.sj.loader.convert;
 
-import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.osjava.StringsToTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/org/osjava/sj/SimpleJndiNewTest.java
+++ b/src/test/java/org/osjava/sj/SimpleJndiNewTest.java
@@ -1,6 +1,6 @@
 package org.osjava.sj;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/osjava/sj/loader/LoadFromJarTest.java
+++ b/src/test/java/org/osjava/sj/loader/LoadFromJarTest.java
@@ -227,7 +227,7 @@ postVisitDirectory: /
         // file:/Users/hot/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar!/org/apache/commons/lang/StringUtils.class
 //        System.out.println(path);
 
-        Class<?> clazz = Class.forName("org.apache.commons.lang.StringUtils");
+        Class<?> clazz = Class.forName("org.apache.commons.lang3.StringUtils");
         URL pathToJar = clazz.getProtectionDomain().getCodeSource().getLocation();
         // file:/Users/hot/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar
         System.out.println(pathToJar);


### PR DESCRIPTION
Commons-lang3 has een out for long.

Note it also requires java 8 as minimum. 

Is it intentional to still be on Java 7? 

We don't want to have two commons-lang libraries on our classpath