### PR TITLE
Give license its name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	<url>https://github.com/h-thurow/Simple-JNDI</url>
 	<licenses>
 		<license>
+			<name>BSD 3-Clause License</name>	
 			<url>
                 https://raw.githubusercontent.com/h-thurow/Simple-JNDI/master/LICENSE.txt
             </url>


### PR DESCRIPTION
By giving it the name the license-maven-plugin will be able to handle it gracefully making the life of your users a bit easier